### PR TITLE
Fix when using `extraQuery` without `queries`

### DIFF
--- a/src/createResolveElements.js
+++ b/src/createResolveElements.js
@@ -178,7 +178,7 @@ export default function createResolveElements(environment) {
 
       if (extraQuery) {
         let extraQueryKey = '__extra';
-        while (hasOwnProperty.call(querySet, extraQueryKey)) {
+        while (querySet && hasOwnProperty.call(querySet, extraQueryKey)) {
           extraQueryKey = `_${extraQueryKey}`;
         }
 


### PR DESCRIPTION
since `querySet` is undefined when `queries` prop is not set, `hasOwnProperty.call(querySet, extraQueryKey)` will throw