### PR TITLE
Continue to display old data while fetching queries

### DIFF
--- a/src/modern/ReadyStateRenderer.js
+++ b/src/modern/ReadyStateRenderer.js
@@ -45,11 +45,16 @@ class SnapshotRenderer extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { querySubscription } = nextProps;
+    const { querySubscription, Component } = nextProps;
     const { readyState } = querySubscription;
 
     if (querySubscription !== this.props.querySubscription) {
-      this.onUpdate(readyState);
+      if (
+        Component !== this.props.Component ||
+        readyState.props != null
+      ) {
+        this.onUpdate(readyState);
+      }
 
       this.selectionReference.dispose();
       this.selectionReference = querySubscription.retain();


### PR DESCRIPTION
I think it makes more sense to display the old data as long as we do not have the new data. Or else add a parameter to the route to activate this behavior ?