### PR TITLE
fix: log fatal query error

### DIFF
--- a/src/renderElement.tsx
+++ b/src/renderElement.tsx
@@ -31,6 +31,15 @@ Props) {
       return undefined;
     }
 
+    if (!props && error) {
+      if (process.env.NODE_ENV !== 'production')
+        console.error(
+          `Fatal error with query \`${querySubscription.getQueryName()}\`: ${error}.`,
+        );
+
+      return null;
+    }
+
     if (!props || !hasComponent) {
       if (process.env.NODE_ENV !== 'production')
         console.error(


### PR DESCRIPTION
Fixes #635

Logs the error from the query if it cause the props to be null.

This doesn't seem particularly great but it does what the other error case does. At least the error is visible now.